### PR TITLE
Add g:lsc_dart_sdk_path config

### DIFF
--- a/autoload/lsc/dart.vim
+++ b/autoload/lsc/dart.vim
@@ -23,9 +23,17 @@ function! lsc#dart#register() abort
 endfunction
 
 function! s:FindCommand() abort
-  let l:dart = s:FindDart()
-  if type(l:dart) != type('') | return v:null | endif
-  let l:bin = fnamemodify(l:dart, ':h')
+  if exists('g:lsc_dart_sdk_path')
+    let l:bin = expand(g:lsc_dart_sdk_path).'/bin'
+    let l:dart = l:bin.'/dart'
+    if !executable(l:dart)
+      echoerr 'The path "'.l:dart.'" is not executable.'
+    endif
+  else
+    let l:dart = s:FindDart()
+    if type(l:dart) != type('') | return v:null | endif
+    let l:bin = fnamemodify(l:dart, ':h')
+  endif
   let l:snapshot = l:bin.'/snapshots/analysis_server.dart.snapshot'
   if !filereadable(l:snapshot)
     echoerr 'Could not find analysis server snapshot at '.l:snapshot

--- a/doc/lsc_dart.txt
+++ b/doc/lsc_dart.txt
@@ -24,6 +24,20 @@ Enable the machine learning model for completion by passing the
 SDK. Defaults to `v:true`, set to `v:false` to disable machine learning
 completion suggestions.
 
+                                                *g:lsc_dart_sdk_path*
+This plugin should auto detect the location of the Dart SDK as long as there
+is a `dart` or `flutter` command available in your `$PATH`. If the detection
+fails set `g:lsc_dart_sdk_path` to the path to the Dart SDK directory. This
+should be the directory above the `/bin/dart` executable. Flutter has it's own
+`dart` executable in addition to the one in the Dart SDK,
+`g:lsc_dart_sdk_path` should be the path for the cached Dart SDK, not the
+flutter SDK. For example, if you are a flutter user and your flutter SDK is
+installed to
+`~/development/flutter` use:
+>
+ let g:lsc_dart_sdk_path = '~/development/flutter/bin/cache/dart-sdk'
+<
+
 COMMANDS                                        *lsc-dart-commands*
 
                                                 *:DartToggleMethodBodyType*


### PR DESCRIPTION
If the autodetection fails for some reason, allow a hardcoded path to
the Dart SDK configured in the `g:lsc_dart_sdk_path` variable.