### PR TITLE
Add g:lsc_dart_command_override

### DIFF
--- a/autoload/lsc/dart.vim
+++ b/autoload/lsc/dart.vim
@@ -21,6 +21,9 @@ function! lsc#dart#register() abort
 endfunction
 
 function! s:FindCommand() abort
+  if exists('g:lsc_dart_command_override')
+    return g:lsc_dart_command_override
+  endif
   if exists('g:lsc_dart_sdk_path')
     let l:bin = expand(g:lsc_dart_sdk_path).'/bin'
     let l:dart = l:bin.'/dart'

--- a/doc/lsc_dart.txt
+++ b/doc/lsc_dart.txt
@@ -12,6 +12,11 @@ plugin.
 
 CONFIGURATION                                   *lsc-dart-configure*
 
+                                                *lsc-dart-command-override*
+                                                *g:lsc_dart_command_override*
+Define the full command to run for the Dart language server. Overrides the SDK
+discovery and any values for |g:lsc_dart_enable_log|, and |g:lsc_dart_sdk_path|.
+
                                                 *lsc-dart-configure-log*
                                                 *g:lsc_dart_enable_log*
 Enable the Analysis Server instrumentation log file by setting


### PR DESCRIPTION
Allow specifying the full command and sidestepping the SDK discovery.
This makes it feasible to switch to script that does things like extra
logging.